### PR TITLE
inheritDoc: Correct example

### DIFF
--- a/pages/tsdoc/tag_inheritdoc.md
+++ b/pages/tsdoc/tag_inheritdoc.md
@@ -36,7 +36,7 @@ export interface IWidget {
   /**
    * Draws the widget on the display surface.
    * @param x - the X position of the widget
-   * @param x - the Y position of the widget
+   * @param y - the Y position of the widget
    */
   public draw(x: number, y: number): void;
 }


### PR DESCRIPTION
Corrects a misnamed `@param` from `x` to `y`.