### PR TITLE
inheritDoc: Correct typeParam reference

### DIFF
--- a/pages/tsdoc/tag_inheritdoc.md
+++ b/pages/tsdoc/tag_inheritdoc.md
@@ -70,7 +70,7 @@ The `@inheritDoc` tag does not copy the entire comment body.  Only the following
 - summary section
 - `@remarks` block
 - `@params` blocks
-- `@typeParm` blocks
+- `@typeParam` blocks
 - `@returns` block
 
 Other tags such as `@defaultValue` or `@example` are not copied, and need to be explicitly included after


### PR DESCRIPTION
Corrects tag reference from `@typeParm` to `@typeParam`.