### PR TITLE
returns: Clarify tag description

### DIFF
--- a/pages/tsdoc/tag_returns.md
+++ b/pages/tsdoc/tag_returns.md
@@ -9,7 +9,7 @@ navigation_source: docs_nav
 **TSDoc standardization:** [core](
 https://github.com/Microsoft/tsdoc/blob/master/tsdoc/src/details/Standardization.ts)
 
-The `@returns` tag is used to document the return type of a function or method parameter.  Being a block tag,
+The `@returns` tag is used to document the return value of a function or method parameter.  Being a block tag,
 `@returns` introduces a TSDoc section that contains all comment text up until the next block tag.
 
 > NOTE: [JSDoc's version](http://usejsdoc.org/tags-returns.html) of the `@returns` tag optionally allows type


### PR DESCRIPTION
Describes `@returns` as documenting return value instead of return type.

I propose this would be clearer. The NOTE box following this talks about how `@returns` in JSDoc documents type but the TSDoc variant doesn't.