### PR TITLE
packageDoc: Correct inheritDoc reference

### DIFF
--- a/pages/tsdoc/tag_packagedocumentation.md
+++ b/pages/tsdoc/tag_packagedocumentation.md
@@ -62,7 +62,7 @@ export interface IWidget {
  * @public
  */
 export class Widget implements IWidget {
-  /** {@inheritDoc IWidget} */
+  /** {@inheritDoc IWidget.render} */
   public render(): void {
     . . .
   }


### PR DESCRIPTION
Corrects `@inheritDoc` reference.

I think this is meant to refer to the overridden method.