### PR TITLE
Clarify comment structure

### DIFF
--- a/pages/tsdoc/doc_comment_syntax.md
+++ b/pages/tsdoc/doc_comment_syntax.md
@@ -47,7 +47,7 @@ export function f2(): void { }
 
 ## Comment structure
 
-The overall anatomy of a TSDoc comment has these components:
+The overall anatomy of an AEDoc comment has these components:
 
 - **The summary section:** The documentation content up until the first block tag is called the "summary".
   The summary section should be brief. On a documentation web site, it will be shown on a page that lists summaries


### PR DESCRIPTION
The `@remarks` tag is an extended TSDoc tag, so specifying that this is the overall anatomy of a TSDoc comment is misleading. Other tools which conform to TSDoc might not support `@remarks` and might have another method of splitting comments into "summary" and "full description" sections.