### PR TITLE
Fix example in "Invoking from a build script"

### DIFF
--- a/pages/setup/invoking.md
+++ b/pages/setup/invoking.md
@@ -208,7 +208,7 @@ const extractorResult: ExtractorResult = Extractor.invoke(extractorConfig, {
 });
 
 if (extractorResult.succeeded) {
-  console.error(`API Extractor completed successfully`);
+  console.log(`API Extractor completed successfully`);
   process.exitCode = 0;
 } else {
   console.error(`API Extractor completed with ${extractorResult.errorCount} errors`


### PR DESCRIPTION
Successful build should log using `console.log`.